### PR TITLE
Fix footer positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,6 +5,9 @@ body {
     padding: 0;
     background: #f4f4f4;
     color: #333;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
 header {
@@ -37,7 +40,7 @@ nav a {
 
 main {
     padding: 20px;
-    min-height: 300px;
+    flex: 1;
 }
 
 footer {
@@ -45,7 +48,5 @@ footer {
     color: #fff;
     text-align: center;
     padding: 1rem 0;
-    position: relative;
-    bottom: 0;
     width: 100%;
 }


### PR DESCRIPTION
The footer was not sticking to the bottom of the page on short content pages. This commit fixes this by using a flexbox layout for the body and making the main content grow to fill the available space.